### PR TITLE
Make calendar responsive based on actual width, not the viewport.

### DIFF
--- a/src/components/calendar.js
+++ b/src/components/calendar.js
@@ -13,7 +13,10 @@ import './calendar.scss';
 export default class Calendar extends Component {
   constructor(props) {
     super(props);
-    this.state = { display: 'horizontal' };
+    this.state = {
+      embedded: props.width && props.height,
+      display: 'horizontal'
+    };
   }
 
   componentDidMount() {
@@ -65,16 +68,20 @@ export default class Calendar extends Component {
   }
 
   displayClass() {
-    return `fc-calendar-container ${this.state.display}`
+    return `fc-calendar-container ${this.state.display} ${this.state.embedded ? 'embedded' : ''}`;
   }
 
   render() {
     const { onBack, onToday, onForward, showDayView,
             showWeekView, showMonthView, view } = this.props;
-
+    // TODO optional
+    const style = {
+      maxWidth: this.props.width,
+      maxHeight: this.props.height
+    };
     return (
-      <div className={this.displayClass()}>
-        <div className='row'>
+      <div className={this.displayClass()} style={style}>
+        <header className='row'>
           <div className='col-sm-5'>
             {this.renderHeader()}
           </div>
@@ -84,8 +91,10 @@ export default class Calendar extends Component {
             <ViewControls viewControlsClass='h2 pull-right' showDayView={showDayView}
               showWeekView={showWeekView} showMonthView={showMonthView} view={view} />
           </div>
-        </div>
-        {this.renderView()}
+        </header>
+        <section>
+          {this.renderView()}
+        </section>
       </div>
     );
   }

--- a/src/components/calendar.scss
+++ b/src/components/calendar.scss
@@ -2,8 +2,22 @@ $border_color: #ddd;
 
 .fc-calendar-container {
   position: relative;
-  min-height: 400px; // TODO
-  width: 100%;
+
+  &.embedded {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+
+    header {
+      order: 1;
+      flex-shrink: 0;
+    }
+
+    section {
+      order: 2;
+      overflow-y: auto;
+    }
+  }
 }
 
 .fc-calendar {


### PR DESCRIPTION
This helps show correct calendar view if only on smaller part of page
